### PR TITLE
Useless Button uses absolute positioning

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -94,20 +94,29 @@ function getRandomNumber(min, max) {
 }
 
 function getRandomLocation() {
+  // find the maximum and minimum locations the useless button can be
   const padding = 20;
   const maxX = window.innerWidth - button.offsetWidth - padding;
   const maxY = window.innerHeight - button.offsetHeight - padding;
   const minX = padding;
   const minY = padding;
   
+  // randomly choose a location
   const randomX = Math.floor(Math.random() * (maxX - minX)) + minX;
   const randomY = Math.floor(Math.random() * (maxY - minY)) + minY;
 
-  return { randomX, randomY };
+  // find the location of useless button's parent node
+  var parentNode = document.getElementById('useless-button').parentNode.getBoundingClientRect();
+
+  // modify the random location by the parent div location so the absolute style renders in the correct position
+  const top = randomY - parentNode.top;
+  const left = randomX - parentNode.left;
+
+  return { left, top };
 }
 
 function buttonTeleport(posX, posY) {
-  button.style.position = "fixed";
+  button.style.position = "absolute";
   button.style.left = `${posX}px`;
   button.style.top = `${posY}px`;
   button.style.transition = "all 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55)";


### PR DESCRIPTION
Resolve #37 

The reason that the bug "Button moves out of canvas after a few random positions" was happening is because the code calculated the buttons location in relation to the entire screen, but assigned the location in relation to it's parent div.

getRandomLocation() was changed to give the location in relation to the parent div of the useless-button. The useless-button CSS position attribute was then changed to "absolute" to ensure the button always renders according to the closest div - the one that getRandomLocation() uses for calculations.