### PR TITLE
feat: add punishment to lazy clickers

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -468,6 +468,16 @@ document.addEventListener("mousemove", (e) => {
   }
 });
 
+document.addEventListener("contextmenu", () => {
+  failedClicks += clicks; // Add all earned clicks to failed count
+  clicks = 0;
+  updateCounter("💥 SIKE YOU THOUGHT! 💥");
+  if (failSound) {
+    failSound.currentTime = 0;
+    failSound.play().catch(() => {});
+  }
+});
+
 // === Background Color Changer ===
 function changeBackgroundColor() {
   const color1 = getRandomColor();


### PR DESCRIPTION

Adds a small “punishment” for players who try to outsmart the game by right-clicking to open the context menu — an unintentional exploit that made clicking way too easy.

**Now, right-clicking will:**
- Add all earned clicks to failed clicks
- Reset the click count
- Play the fail sound
- Display a “💥 SIKE YOU THOUGHT! 💥” message

**Why**

Right-clicking used to bypass the game’s button avoidance logic, letting users “cheat” for easy clicks. This closes that loophole while keeping things funny and fair.

**closes #54**