### PR TITLE
Quick fix: Correct favicon path to use relative

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/clock.css" />
-    <link rel="icon" type="image/x-icon" href="/image/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="image/favicon.ico" />
   </head>
 
   <body>


### PR DESCRIPTION
## Quick fix — favicon path

Hello @thecodersroom

This is a small, fast fix to correct the favicon path in `index.html` which was using an absolute or incorrect path that caused browser console errors like `Failed to load resource: net::ERR_FILE_NOT_FOUND` for the favicon. Using a relative path ensures the favicon loads when opening the site locally or when hosted.

Files changed
-------------
- `index.html`
  - Changed:
    - `<link rel="icon" type="image/x-icon" href="/image/favicon.ico" />` 
    - to
    - `<link rel="icon" type="image/x-icon" href="image/favicon.ico" />`
  
Why this change
----------------
- The previous path started with `/` which resolves to the filesystem root in `file://` contexts and may point to an incorrect location on Windows (e.g. `/D:/image/favicon.ico`). This caused `ERR_FILE_NOT_FOUND` when loading the page locally.
- A relative path (`image/favicon.ico`) resolves correctly relative to the repository root and works both when opened via `file://` and when hosted.

If you find this PR suitable for merging, I would be grateful if you could kindly add the `hacktoberfest-accepted` label to this PR . This will ensure that my contribution is counted for Hacktoberfest and will greatly support my participation in the event.

Thank you very much for your time and consideration

## Screenshort
<img width="1904" height="704" alt="Screenshot_2" src="https://github.com/user-attachments/assets/ca7b5837-0744-4798-8d1a-6e2a038aa3f1" />

