### PR TITLE
Fix: align Theme and Audio buttons on same line, remove duplicate timer (#129)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -788,7 +788,8 @@ h1::after {
   }
 }
 
-.control-buttons button {
+.control-buttons button,
+.top-right-controls button {
   width: 56px;
   height: 56px;
   border: none;
@@ -806,18 +807,21 @@ h1::after {
   position: relative;
 }
 
-.control-buttons button:hover {
+.control-buttons button:hover,
+.top-right-controls button:hover {
   transform: scale(1.1);
   box-shadow: var(--shadow-xl);
   border-color: var(--accent-color);
 }
 
-.control-buttons button:active {
+.control-buttons button:active,
+.top-right-controls button:active {
   transform: scale(0.95);
 }
 
 /* Tooltip */
-.control-buttons button::before {
+.control-buttons button::before,
+.top-right-controls button:before{
   content: attr(title);
   position: absolute;
   right: calc(100% + var(--space-md));
@@ -832,8 +836,15 @@ h1::after {
   transition: opacity var(--transition-base);
 }
 
-.control-buttons button:hover::before {
+.control-buttons button:hover::before,
+.top-right-controls button:hover::before {
   opacity: 1;
+}
+
+/* make theme and sound in same line */
+.theme-sound {
+  display: flex;
+  gap: 10px;
 }
 
 @media (max-width: 768px) {

--- a/index.html
+++ b/index.html
@@ -21,12 +21,12 @@
   <div class="dev-comment" style="top: 75%; left: 70%;">// Hope the boss doesn't see this.</div>
   <div class="dev-comment" style="top: 85%; left: 30%;">// A single click... a single dream...</div>
 </div>
-    <div class="clock-container">
+    <!-- <div class="clock-container">
       <div class="clock">
         <span id="hrs">00</span>:<span id="min">00</span>:<span id="sec"
           >00</span
         >
-      </div>
+      </div> -->
     </div>
     <div id="time-attack-progress-bar" style="display: none;">
     <div id="time-attack-progress-inner"></div>
@@ -55,8 +55,6 @@
 </div>
 <button id="share-button">Share My Score</button>
       <div class="control-buttons">
-        <button id="theme-toggle">🎨</button>
-        <button id="sound-toggle">🎵</button>
         <button id="time-attack-button">⏱️ Time Attack</button>
       </div>
       <div id="counter">Clicks: 0 | Failed clicks: 0</div>
@@ -65,17 +63,17 @@
         <span class="achievement-text"> </span>
       </div>
       <div id="quote" class="quote">"Loading some wisdom..."</div>
-      <div id="timer" class="timer">Time spent doing nothing: 00:00</div>
-      <div id="time-attack-timer" class="timer" style="display: none;">Time Left: 60s</div>
+<div id="time-attack-timer" class="timer" style="display: none;">Time Left: 60s</div>
 
-      <div id="counter"></div>
-
-      <div id="quote" class="quote">Click the button to begin your pointless journey! 🚀</div>
     </div>
 
      <div class="top-right-controls">
       <button id="dark-mode-toggle" title="Toggle Dark Mode">🌙</button>
-
+      <div class="theme-sound">
+        <button id="theme-toggle" title="Theme">🎨</button>
+        <button id="sound-toggle" title="Sound Settings">🎵</button>
+      </div>
+    
       <div class="clock-container">
         <div class="clock">
           <span id="hrs">00</span>:<span id="min">00</span>:<span id="sec"


### PR DESCRIPTION
## Description  
Fixes duplicate Theme, Audio, and Timer controls.  
Previously, both top and bottom control sets existed — the top looked better but didn’t work.  
Now, only the top-right controls remain (fully functional), with Theme and Audio buttons aligned on the same line and a single visible timer.

---

## Type of Change  
- [x] Bug fix  
- [x] UI/UX improvement  

---

## Changes Made  
- Removed duplicate bottom Theme, Audio, and Timer controls.  
- Kept and activated top-right controls (Theme and Audio).  
- Placed Theme and Audio buttons on one line for cleaner layout.  
- Retained only one active timer visible during scroll.  
- Unified button styling to match existing theme system.  

---

## Testing  
- [x] Theme toggle works and updates across all modes.  
- [x] Audio toggle functions correctly.  
- [x] Timer visible and updates in real time.  
- [x] Tested on Chrome, Firefox, and mobile view.  
- [x] No new console errors or warnings.  

---

## Screenshots  

### Before  
Two sets of Theme/Audio buttons (top and bottom) and duplicate timer.  
<img width="606" height="638" alt="image" src="https://github.com/user-attachments/assets/0c3e3e96-6e46-4329-a6c5-3476d0287313" />

### After  
Single top-right control bar with aligned Theme and Audio buttons and one active timer.  
<img width="1375" height="867" alt="image" src="https://github.com/user-attachments/assets/d8dffd83-78ce-463e-a611-e7915cb992c8" />
<img width="1615" height="729" alt="image" src="https://github.com/user-attachments/assets/fa701a02-432b-44ec-9c41-a5754bc5d98f" />

---
