### PR TITLE
Fix: Replace JS alert with theme-friendly modal for Time Attack compl…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1041,6 +1041,98 @@ h1::after {
   transform: translateY(0);
 }
 
+/* === TIME ATTACK RESULT MODAL === */
+.time-attack-result {
+  max-width: 450px;
+  text-align: center;
+}
+
+.result-icon {
+  font-size: 80px;
+  margin-bottom: var(--space-lg);
+  animation: pulseGlow 2s infinite;
+}
+
+@keyframes pulseGlow {
+  0%, 100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 20px var(--accent-color));
+  }
+  50% {
+    transform: scale(1.1);
+    filter: drop-shadow(0 0 40px var(--accent-color));
+  }
+}
+
+.result-stats {
+  margin: var(--space-2xl) 0;
+  padding: var(--space-xl);
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 2px solid var(--border-color);
+}
+
+.result-stat-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.result-label {
+  font-size: var(--text-lg);
+  color: var(--text-color);
+  opacity: 0.9;
+}
+
+.result-value {
+  font-size: 64px;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--accent-color), var(--button-gradient-end));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  line-height: 1;
+  margin: var(--space-sm) 0;
+  animation: countUp 0.5s ease-out;
+}
+
+@keyframes countUp {
+  from {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.new-record {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: #ffd700;
+  text-shadow: 0 0 20px rgba(255, 215, 0, 0.5);
+  margin: var(--space-lg) 0;
+  animation: celebrateRecord 1s infinite;
+}
+
+@keyframes celebrateRecord {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+#time-attack-close-btn {
+  background: linear-gradient(135deg, var(--button-gradient-start), var(--button-gradient-end));
+  color: white;
+  padding: var(--space-md) var(--space-3xl);
+  font-size: var(--text-xl);
+  min-width: 150px;
+}
+
 /* === THEME SELECTOR MODAL === */
 #theme-selector {
   position: fixed;
@@ -1821,7 +1913,7 @@ body.flipped {
 
 .shop-item button:disabled {
   background: rgba(255, 255, 255, 0.1);
-  color: var(--text-secondary);
+  color: var (--text-secondary);
   cursor: not-allowed;
   box-shadow: none;
 }

--- a/index.html
+++ b/index.html
@@ -105,6 +105,27 @@
       </div>
     </div>
 
+    <!-- Time Attack Result Modal -->
+    <div id="time-attack-result-popup" class="popup-container">
+      <div class="popup-content time-attack-result">
+        <div class="result-icon">⏰</div>
+        <h2>Time's Up!</h2>
+        <div class="result-stats">
+          <div class="result-stat-item">
+            <span class="result-label">You clicked</span>
+            <span class="result-value" id="time-attack-final-score">0</span>
+            <span class="result-label">times!</span>
+          </div>
+        </div>
+        <div id="time-attack-new-record" class="new-record" style="display: none;">
+          🏆 NEW HIGH SCORE! 🏆
+        </div>
+        <div class="popup-buttons">
+          <button id="time-attack-close-btn">OK</button>
+        </div>
+      </div>
+    </div>
+
     <div id="sound-panel" class="popup-container">
       <div class="popup-content">
         <h2>🎵 Sound Settings</h2>

--- a/js/script.js
+++ b/js/script.js
@@ -1333,14 +1333,38 @@ function endTimeAttack() {
     timeAttackProgressBar.style.display = 'none';
   }
 
-  // Show a simple alert. You can make a custom popup later.
-  alert(`Time's up! You clicked ${timeAttackScore} times!`);
+  // Show custom themed modal instead of alert
+  const resultPopup = document.getElementById('time-attack-result-popup');
+  const finalScoreDisplay = document.getElementById('time-attack-final-score');
+  const newRecordDisplay = document.getElementById('time-attack-new-record');
+  
+  if (finalScoreDisplay) {
+    finalScoreDisplay.textContent = timeAttackScore;
+  }
 
-  if (timeAttackScore > timeAttackHighScore) {
+  // Check for new high score
+  const isNewRecord = timeAttackScore > timeAttackHighScore;
+  
+  if (isNewRecord) {
     timeAttackHighScore = timeAttackScore;
     localStorage.setItem('timeAttackHighScore', timeAttackHighScore);
     if(timeAttackHighScoreDisplay) timeAttackHighScoreDisplay.textContent = timeAttackHighScore;
     if(quoteDiv) quoteDiv.textContent = `🏆 New Time Attack High Score: ${timeAttackHighScore}!`;
+    
+    // Show new record message
+    if (newRecordDisplay) {
+      newRecordDisplay.style.display = 'block';
+    }
+  } else {
+    // Hide new record message
+    if (newRecordDisplay) {
+      newRecordDisplay.style.display = 'none';
+    }
+  }
+  
+  // Show the custom modal
+  if (resultPopup) {
+    resultPopup.classList.add('show');
   }
   
   if(timeAttackButton) timeAttackButton.disabled = false;
@@ -1363,6 +1387,28 @@ if (timeAttackButton) {
   timeAttackButton.addEventListener('click', () => {
     if (!isTimeAttackActive) {
       startTimeAttack();
+    }
+  });
+}
+
+// Add listener for Time Attack result modal close button
+const timeAttackCloseBtn = document.getElementById('time-attack-close-btn');
+if (timeAttackCloseBtn) {
+  timeAttackCloseBtn.addEventListener('click', () => {
+    const resultPopup = document.getElementById('time-attack-result-popup');
+    if (resultPopup) {
+      resultPopup.classList.remove('show');
+    }
+    playSound(clickSound);
+  });
+}
+
+// Close modal on background click
+const timeAttackResultPopup = document.getElementById('time-attack-result-popup');
+if (timeAttackResultPopup) {
+  timeAttackResultPopup.addEventListener('click', (e) => {
+    if (e.target === timeAttackResultPopup) {
+      timeAttackResultPopup.classList.remove('show');
     }
   });
 }
@@ -1404,7 +1450,11 @@ document.addEventListener('keydown', (e) => {
   if ((e.key === 's' || e.key === 'S') && !e.metaKey && !e.ctrlKey) { e.preventDefault(); soundToggle?.click(); }
   if ((e.key === 'i' || e.key === 'I') && !e.metaKey && !e.ctrlKey) { e.preventDefault(); impossibleToggle?.click(); }
   if (e.key === 'Escape') {
-    themeSelector?.classList.remove('show'); soundPanel?.classList.remove('show'); popupContainer?.classList.remove('show');
+    themeSelector?.classList.remove('show'); 
+    soundPanel?.classList.remove('show'); 
+    popupContainer?.classList.remove('show');
+    const timeAttackResultPopup = document.getElementById('time-attack-result-popup');
+    timeAttackResultPopup?.classList.remove('show');
   }
 });
 


### PR DESCRIPTION
- FIXED ISSUE #143 

- Added custom modal popup for Time Attack results display
- Implemented modern CSS styling with animations and theme support
- Added pulsing icon, gradient text, and celebration effects for new records
- Included keyboard support (Escape key) and click-outside-to-close
- Modal adapts to all existing themes using CSS variables

<img width="465" height="687" alt="image" src="https://github.com/user-attachments/assets/0116690e-3dcf-4c1f-9dc6-c4767867b99d" />
