### PR TITLE
Fix tooltip positioning for top panel buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2224,27 +2224,26 @@ body.flipped {
 
 /* Ensure tooltips work for buttons inside panel */
 #top-panel .panel-buttons button::before {
-  content: attr(title);
-  position: absolute;
-  bottom: calc(100% + 8px); /* Position above the button */
-  left: 50%;
-  transform: translateX(-50%); /* Center horizontally */
-  background: linear-gradient(135deg, rgba(0, 0, 0, 0.95), rgba(0, 0, 0, 0.85));
-  color: white;
-  padding: var(--space-sm) var(--space-md);
-  border-radius: var(--radius-sm);
-  font-size: var(--text-sm);
-  white-space: nowrap;
-  opacity: 0;
-  pointer-events: none;
-  transition: all 0.2s ease-out; /* Faster transition */
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+    content: attr(title);
+    position: absolute;
+    top: calc(100% + 8px); /* Changed to position below the button */
+    left: 50%;
+    transform: translateX(-50%);
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.95), rgba(0, 0, 0, 0.85));
+    color: white;
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: all 0.2s ease-out;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.1);
 }
-
 #top-panel .panel-buttons button:hover::before {
-  opacity: 1;
-  transform: translateX(-50%) translateY(-5px); /* Add slight upward move */
+    opacity: 1;
+    transform: translateX(-50%) translateY(5px); /* Changed to move down on hover */
 }
 
 


### PR DESCRIPTION
Fixed the tooltip positioning for the dark mode, theme, and sound toggle buttons in the top panel. Previously, tooltips appeared above the buttons and went off-screen. Now they appear below, staying visible.

## Changes Made
- Updated `css/style.css` to change `bottom` to `top` in the `::before` pseudo-element for `#top-panel .panel-buttons button`.
- Adjusted hover animation to move the tooltip downward.

## Testing
- Hover over the top panel buttons; tooltips should now appear below and within the viewport.

## Screenshots 

Before:

<img width="1311" height="232" alt="Before_Fix" src="https://github.com/user-attachments/assets/8a9dac9c-778e-4d4f-aa91-e2face096bc6" />

After:

<img width="1283" height="187" alt="After_Fix" src="https://github.com/user-attachments/assets/d6061981-0394-4157-b111-ad949479e1cf" />

Closes #180 