### PR TITLE
Implemented Functionality for Current Shop Items

### DIFF
--- a/css/shop.css
+++ b/css/shop.css
@@ -86,11 +86,60 @@
   box-shadow: var(--shadow-md, 0 0 12px rgba(0, 162, 255, 0.7));
 }
 
+.shop-item button.owned {
+  background: var(--success-gradient, linear-gradient(135deg, #34d399, #059669));
+  opacity: 0.8;
+  cursor: default;
+}
+
+.shop-item button.expensive {
+  background: var(--error-gradient, linear-gradient(135deg, #ef4444, #991b1b));
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
 .shop-item button:disabled {
   background: var(--button-disabled-bg, rgba(255,255,255,0.08));
   color: var(--text-disabled, #777);
   box-shadow: none;
   cursor: not-allowed;
+}
+
+/* Purchase animation */
+@keyframes purchaseSuccess {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+.shop-item.purchase-animation {
+  animation: purchaseSuccess 0.5s ease;
+}
+
+/* Item cost states */
+.item-cost.owned {
+  color: var(--success-color, #34d399);
+}
+
+.item-cost.expensive {
+  color: var(--error-color, #ef4444);
+}
+
+/* Preview hover effect */
+.shop-item[data-previewing="true"] {
+  border-color: var(--accent-color, #00c6ff);
+  box-shadow: 0 0 15px var(--accent-color, #00c6ff);
+}
+
+/* Coin update animation */
+@keyframes coinUpdate {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.2); }
+  100% { transform: scale(1); }
+}
+
+.coin-update {
+  animation: coinUpdate 0.5s ease;
 }
 
 /* === MOBILE LAYOUT === */


### PR DESCRIPTION
Added functionality for current shop items : 

Deducts coins on purchase and saves balance to localStorage.
Saves ownership (ownedNothingItems) and active persistent items (activeShopItems)
Applies item effects immediately and restores persistent effects after reload (glow, dancing duck, particle burst, ambient hum
Disables/marks purchased buttons as "Owned" and adds affordable/expensive/owned UI states (updated css/shop.css)

Adds hover preview, confetti + purchase notification, and a small coin-update animation for feedback

Adds resetShop() hook to wired the reset button to clear purchases and deactivate effects

updates - 
<img width="3707" height="2022" alt="Screenshot (185)" src="https://github.com/user-attachments/assets/b679b150-9bf0-4164-bc71-d925f500b98d" />



