### PR TITLE
fix: shop UI refreshes when coin balance changes (#231)

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,13 @@
 import { submitScore } from './leaderboard.js';
 
+// Import refreshShop with optional chaining to handle cases where shop.js might not be loaded
+let refreshShop = null;
+import('./shop.js').then(shopModule => {
+  refreshShop = shopModule.refreshShop;
+}).catch(() => {
+  // shop.js might not be available, that's okay
+});
+
 // sound files
 const clickSoundFiles = [
   "audio/click1.mp3","audio/click2.wav","audio/click3.wav",
@@ -1099,6 +1107,10 @@ function addCoins(amount) {
   nothingCoins += amount;
   localStorage.setItem('nothingCoins', nothingCoins);
   updateCoinDisplay();
+  // Refresh shop if available
+  if (refreshShop) {
+    refreshShop();
+  }
 }
 
 function checkCoinReward() {

--- a/js/shop.js
+++ b/js/shop.js
@@ -306,6 +306,11 @@ function resetShop() {
   renderShop();
 }
 
+// Export function to refresh shop when coin balance changes
+export function refreshShop() {
+  renderShop();
+}
+
 // Initialize
 document.addEventListener('DOMContentLoaded', initializeShop);
 
@@ -324,6 +329,9 @@ document.addEventListener("DOMContentLoaded", () => {
   openBtn.addEventListener("click", () => {
     shop.classList.remove("closed", "closing");
     shop.classList.add("opening");
+    
+    // Refresh shop to show latest coin balance
+    renderShop();
 
     setTimeout(() => {
       shop.classList.remove("opening");


### PR DESCRIPTION
Fixes #231

This PR fixes the issue where the shop UI didn’t update when the coin balance changed.

### **✨Changes Made:**
• Exported `refreshShop()` from shop.js to re-render the shop UI dynamically.
• Called `renderShop()` when the shop opens to show the latest coin balance.
• Imported `refreshShop()` in script.js using dynamic import to avoid circular dependencies.
• Triggered `refreshShop()` inside `addCoins()` to keep the UI in sync.
• Updated button states ("Buy" vs "Too Expensive") instantly without page reload.

### **⚙️How It Works:**
• When coins are earned, `addCoins()` triggers `refreshShop()` to update the shop instantly.
• Opening the shop always shows the latest balance.
• Buttons now reflect affordability in real time.

### **✅Testing Done:**
• Verified that coin balance updates appear instantly in the shop.
• Confirmed button states switch correctly.
• Ensured no circular dependency errors occur.