### PR TITLE
Fix: File Structure Section Formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@
 Click the most important button you’ll ever encounter — that still does *absolutely nothing*.
 
 ---
-## File structure
+## File Structure
+```
 the-button-that-does-nothing/
 ├── .vscode/
-│    └── settings.json
+│   └── settings.json
 ├── audio/
 │   ├── 8-bit.mp3
 │   ├── boss.mp3
@@ -99,9 +100,8 @@ the-button-that-does-nothing/
 ├── motivation.html
 ├── package-lock.json
 ├── README.md
-└──THEME_SYSTEM.md
-
----
+└── THEME_SYSTEM.md
+```
 
 ## ⚡ About the Project
 


### PR DESCRIPTION
## Description
Fixed the file structure section in README.md that was displaying as a single line instead of a properly formatted tree structure.
Fixes #241 