### PR TITLE
Fix: Removed unnecessary Name text field from Nothing Shop (Issue #264)

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,11 +274,7 @@
     <button id="close-shop" class="shop-close-btn" title="Close Shop">✖</button>
   </div>
 
-  <div id="user-section" class="user-section">
-    <input type="text" id="username" placeholder="Enter your name" />
-    <button id="saveName">Save</button>
-    <p id="greeting"></p>
-  </div>
+  
 
   <div id="shop-items" class="shop-items"></div>
 </div>


### PR DESCRIPTION
@AbdulKhadhar fixes #264
Removed the redundant "Name" text field from the Nothing Shop, since player names are already stored in the Leaderboard.

 before:
<img width="323" height="217" alt="Screenshot 2025-10-29 at 6 57 14 PM" src="https://github.com/user-attachments/assets/ae0c1f1f-7924-4034-8a0c-44ee483d6ab2" />
after :
<img width="331" height="609" alt="Screenshot 2025-10-29 at 6 56 47 PM" src="https://github.com/user-attachments/assets/e21cfe95-9bfe-4d4d-9878-ddc4d7ecdb2b" />
