### PR TITLE
Make text black in pastel theme for better readability

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -295,8 +295,8 @@ body::after {
   }
 }
 
-/* 🩷 Light (Pink) Theme — EVERYTHING BLACK */
-/* 🩷 Light Theme — Make only text black, keep card color same */
+
+/*Light Theme — Make only text black, keep card color same */
 [data-theme="light"] {
   --text-color: #000000;
   --text-secondary: #000000;
@@ -379,8 +379,8 @@ body::after {
 [data-theme="pastel"] {
   --bg-start: #ffcce7;
   --bg-end: #d5f5e3;
-  --text-color: #5d5d5d;
-  --text-secondary: rgba(93, 93, 93, 0.6);
+  --text-color: #000000; /* all text black */
+  --text-secondary: #000000; /* secondary text black too */
   --card-bg: rgba(255, 255, 255, 0.6);
   --card-bg-solid: rgba(255, 255, 255, 0.8);
   --accent-color: #ff8fa3;
@@ -388,6 +388,41 @@ body::after {
   --button-gradient-start: #ffb3c6;
   --button-gradient-end: #ff8fa3;
 }
+
+/* 🖋️ Force all text inside pastel theme to black */
+[data-theme="pastel"] body,
+[data-theme="pastel"] h1,
+[data-theme="pastel"] h2,
+[data-theme="pastel"] h3,
+[data-theme="pastel"] h4,
+[data-theme="pastel"] h5,
+[data-theme="pastel"] h6,
+[data-theme="pastel"] p,
+[data-theme="pastel"] span,
+[data-theme="pastel"] a,
+[data-theme="pastel"] li,
+[data-theme="pastel"] label,
+[data-theme="pastel"] div,
+[data-theme="pastel"] small,
+[data-theme="pastel"] strong,
+[data-theme="pastel"] em {
+  color: #000000 !important;
+}
+
+/* 💬 Ensure all text inside cards, quotes, and content blocks is black */
+[data-theme="pastel"] .card *,
+[data-theme="pastel"] .quote-card *,
+[data-theme="pastel"] .entry *,
+[data-theme="pastel"] .quote *,
+[data-theme="pastel"] .content *,
+[data-theme="pastel"] .text *,
+[data-theme="pastel"] .box *,
+[data-theme="pastel"] .container * {
+  color: #000000 !important;
+  fill: #000000 !important;
+  stroke: #000000 !important;
+}
+
 
 [data-theme="solarized"] {
   --bg-start: #002b36;


### PR DESCRIPTION
@AbdulKhadhar  i have made the relevant changes and i have checked its not affecting any main page functionality
old
<img width="1058" height="790" alt="Screenshot 2025-10-29 at 19 50 52" src="https://github.com/user-attachments/assets/1b0057b5-8525-4824-944f-297a60f17fd0" />

now

<img width="1207" height="803" alt="Screenshot 2025-10-29 at 19 51 21" src="https://github.com/user-attachments/assets/c06c4bda-b04d-4def-b566-908ab33be425" />
