### PR TITLE
fix(audio): Make clickMore.js respect sound settings (fixes #284)

### DIFF
--- a/js/clickMore.js
+++ b/js/clickMore.js
@@ -13,7 +13,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (clickCount >= randomTrigger) {
       clickMoreSound.currentTime = 0;
-      clickMoreSound.play();
+
+      // === THIS IS THE FIX ===
+      if (soundsEnabled) {
+        clickMoreSound.play();
+      }
+      // === END OF FIX ===
 
       // Reset for next random trigger
       clickCount = 0;


### PR DESCRIPTION
Hi @Abdulkhaidhar,

Thanks for the guidance on this! As we discussed, the bug was in `js/clickMore.js`.

This PR wraps the `clickMoreSound.play()` call in an `if (soundsEnabled)` check, which fixes the issue.

Let me know if any other changes are needed!