### PR TITLE
fix: Prevent keyboard click on button (fixes #301)

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1887,11 +1887,6 @@ if (impossibleToggle) { // Reset magnetic on impossible toggle
 // === Keyboard Navigation ===
 document.addEventListener('keydown', (e) => {
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
-  if (e.key === ' ' || e.key === 'Enter') {
-    if (document.activeElement === button || !document.activeElement || document.activeElement === document.body) {
-      e.preventDefault(); button?.click();
-    }
-  }
   if ((e.key === 't' || e.key === 'T') && !e.metaKey && !e.ctrlKey) { e.preventDefault(); themeToggle?.click(); }
   if ((e.key === 's' || e.key === 'S') && !e.metaKey && !e.ctrlKey) { e.preventDefault(); soundToggle?.click(); }
   if ((e.key === 'i' || e.key === 'I') && !e.metaKey && !e.ctrlKey) { e.preventDefault(); impossibleToggle?.click(); }


### PR DESCRIPTION
Hi @Abdulkhaidhar, here is the fix for #301.

I've removed the keydown event listener for the Space and Enter keys that was triggering the button click.

Let me know if you need anything else!