### PR TITLE
feat: add contributors page

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="description" content="Contributors of The Button That Does Nothing"/>
+  <link rel="icon" type="image/svg+xml" href="/image/favicon.ico"/>
+  <link rel="stylesheet" href="/css/style.css"/>
+  <link rel="stylesheet" href="/css/contributors.css"/>
+  <title>Contributors — The Button That Does Nothing</title>
+</head>
+<body class="bg">
+  <main class="container">
+    <header class="page-header">
+      <h1>The Legends Behind The Button</h1> 
+      <p class="subtitle">Thanks to everyone who clicked… and actually built things.</p>
+      <a class="btn btn-secondary" href="/index.html">← Back to the Button</a>
+    </header>
+
+    <section id="contributors" class="contributors-grid" aria-live="polite"></section>
+
+    <template id="contributor-card">
+    <a class="contrib-card" target="_blank" rel="noopener">
+        <img class="contrib-avatar" alt="avatar" />
+        <div class="contrib-meta">
+        <span class="contrib-name"></span>
+        <span class="contrib-commits"></span>
+        </div>
+    </a>
+    </template>
+
+
+    <footer class="page-footer">
+      <p class="muted">Data from GitHub API • Updated live</p>
+    </footer>
+  </main>
+  <script>
+    window.__REPO__ = { owner: "thecodersroom", name: "the-button-that-does-nothing" };
+  </script>
+  <script type="module" src="/js/contributors.js"></script>
+</body>
+</html>

--- a/css/contributors.css
+++ b/css/contributors.css
@@ -1,0 +1,174 @@
+/* ====================== Contributors Page (full CSS) ====================== */
+:root {
+  --bg: #0b0e13;
+  --card-bg: rgba(20,20,28,.75);
+  --panel: rgba(30,30,40,.6);
+  --border: rgba(255,255,255,.10);
+  --border-weak: rgba(255,255,255,.08);
+  --text: #e5e7eb;
+  --muted: #9aa0a6;
+  --accent: #60a5fa;    /* azul del tema */
+}
+
+/* Fondo + tipografía (si usas otra hoja global, esto no molesta) */
+.bg { background: var(--bg); color: var(--text); }
+
+/* Layout general de la página */
+.container { max-width: 1100px; margin: 0 auto; padding: 2rem 1rem; }
+.page-header { text-align: center; margin-bottom: 1.25rem; }
+.page-header h1 { font-size: clamp(1.8rem, 3.5vw, 3.2rem); margin: .25rem 0; }
+.subtitle { color: var(--muted); margin: .25rem 0 1rem; }
+
+/* Botón volver */
+.btn, .btn.btn-secondary {
+  display: inline-block; padding: .6rem .9rem; border-radius: 10px;
+  border: 1px solid var(--border-weak); color: var(--text); text-decoration: none;
+  background: transparent; transition: border-color .15s, box-shadow .15s, transform .1s;
+}
+.btn:hover, .btn.btn-secondary:hover {
+  border-color: var(--accent); box-shadow: 0 0 0 3px rgba(96,165,250,.15); transform: translateY(-1px);
+}
+
+/* ===================== GRID + CARDS (con overrides fuertes) ===================== */
+
+/* Grid de contribuidores */
+#contributors.contributors-grid {
+  display: grid !important;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)) !important;
+  gap: 14px !important;
+  margin-top: 1rem !important;
+}
+
+/* Card (avatar | texto) */
+.contrib-card {
+  display: grid !important;
+  grid-template-columns: 56px 1fr !important;
+  align-items: center !important;
+  gap: 12px !important;
+  padding: 12px !important;
+  border: 1px solid var(--border-weak) !important;
+  border-radius: 12px !important;
+  background: var(--card-bg) !important;
+  color: var(--text) !important;
+  text-decoration: none !important;
+  min-width: 0 !important; /* permite truncar texto en grid */
+  transition: transform .15s ease, border-color .15s ease, box-shadow .15s ease !important;
+}
+.contrib-card:hover {
+  transform: translateY(-2px) !important;
+  border-color: var(--accent) !important;
+  box-shadow: 0 6px 18px rgba(0,0,0,.35) !important;
+}
+
+/* Avatar SIEMPRE pequeño */
+.contrib-card .contrib-avatar,
+#contributors img.contrib-avatar {
+  width: 56px !important;
+  height: 56px !important;
+  border-radius: 50% !important;
+  object-fit: cover !important;
+  border: 1px solid var(--border-weak) !important;
+  background: #111 !important;
+  display: block !important;
+}
+
+/* Texto meta */
+.contrib-meta { display: flex !important; flex-direction: column !important; min-width: 0 !important; }
+
+/* Nombre con ellipsis (una línea) */
+.contrib-name {
+  font-weight: 700 !important;
+  line-height: 1.1 !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+  max-width: 100% !important;
+}
+
+/* Commits */
+.contrib-commits { font-size: .9rem !important; color: var(--muted) !important; overflow-wrap: anywhere !important; }
+
+/* Estados (cargando / error) */
+.status { text-align: center !important; padding: 1rem !important; color: var(--muted) !important; }
+.status.error { color: #fca5a5 !important; }
+
+/* Footer */
+.page-footer { margin-top: 1.5rem !important; text-align: center !important; color: var(--muted) !important; }
+
+/* ================================ Responsive ================================ */
+
+@media (max-width: 680px) {
+  #contributors.contributors-grid {
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)) !important;
+  }
+  .contrib-card {
+    grid-template-columns: 48px 1fr !important;
+    gap: 10px !important;
+    padding: 10px !important;
+  }
+  .contrib-card .contrib-avatar { width: 48px !important; height: 48px !important; }
+}
+
+@media (max-width: 420px) {
+  #contributors.contributors-grid { grid-template-columns: 1fr !important; }
+}
+
+/* Accesibilidad: menos animaciones si el usuario lo pide */
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation: none !important; }
+}
+.page-header h1 {
+  padding-bottom: 12px;   /* deja espacio para la línea */
+  position: relative;
+}
+
+.page-header .subtitle {
+  margin-top: 15px;       /* baja el subtítulo */
+}
+
+/* Botón estilo tema para "View Contributors" */
+.view-contrib-btn {
+  --btn-grad: linear-gradient(135deg, rgba(96,165,250,.18), rgba(167,139,250,.18));
+  --btn-ring: rgba(96,165,250,.14);
+
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border, rgba(255,255,255,.1));
+  background: var(--btn-grad);
+  color: var(--text, #e5e7eb);
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: .2px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 10px 24px rgba(0,0,0,.25);
+  transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease, color .18s ease;
+}
+
+.view-contrib-btn:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent, #60a5fa);
+  box-shadow:
+    0 16px 36px rgba(0,0,0,.45),
+    0 0 0 4px var(--btn-ring);
+  color: #ffffff;
+}
+
+.view-contrib-btn:active { transform: translateY(-1px) scale(.99); }
+
+.view-contrib-btn .dot {
+  width: 8px; height: 8px; border-radius: 999px;
+  background: radial-gradient(circle at 30% 30%, #93c5fd, #7c3aed);
+  box-shadow: 0 0 8px rgba(124,58,237,.6);
+}
+
+/* Accesibilidad */
+.view-contrib-btn:focus-visible {
+  outline: none;
+  box-shadow:
+    0 16px 36px rgba(0,0,0,.45),
+    0 0 0 4px var(--btn-ring),
+    0 0 0 2px var(--accent, #60a5fa) inset;
+}

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
   <link rel="stylesheet" href="css/downloadButton.css" />
   <link rel="stylesheet" href="css/clickEffects.css" />
   <link rel="stylesheet" href="css/themeUnlock.css" />
-
+  <link rel="stylesheet" href="css/contributors.css" />
 
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
 
@@ -592,6 +592,12 @@
   <a href="motivation.html" class="motivation-btn">
     💭 Lack Motivation?
   </a>
+  <p style="text-align:center;margin-top:12px">
+    <a href="/contributors.html" class="view-contrib-btn">
+      <span class="dot" aria-hidden="true"></span>
+      View Contributors
+    </a>
+  </p>
   <button class="recenter-btn" id="recenter" title="Recenter View">
     <svg xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 576 512"><!--!Font Awesome Free v7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -1,0 +1,49 @@
+const { owner, name } = window.__REPO__ || {};
+const API = `https://api.github.com/repos/${owner}/${name}/contributors?per_page=100`;
+const grid = document.getElementById("contributors");
+const tpl = document.getElementById("contributor-card");
+
+/** Util: crea una card */
+function renderCard(user) {
+  const node = tpl.content.cloneNode(true);
+  const a = node.querySelector(".contrib-card");
+  const img = node.querySelector(".contrib-avatar");
+  const nameEl = node.querySelector(".contrib-name");
+  const commitsEl = node.querySelector(".contrib-commits");
+
+  a.href = user.html_url;
+  img.src = user.avatar_url;
+  img.alt = `${user.login} avatar`;
+
+  nameEl.textContent = user.login;
+  commitsEl.textContent = `${user.contributions} commit${user.contributions !== 1 ? "s" : ""}`;
+
+  // 🔽 Añade los títulos (tooltips) aquí
+  nameEl.title = user.login;
+  a.title = `${user.login} — ${user.contributions} commits`;
+
+  grid.appendChild(node);
+}
+
+/** Loader + fallback */
+function setStatus(msg, isError=false) {
+  grid.innerHTML = `<div class="status ${isError ? "error" : ""}">${msg}</div>`;
+}
+
+(async function load() {
+  try {
+    setStatus("Loading contributors…");
+    const res = await fetch(API, { headers: { "Accept": "application/vnd.github+json" }});
+    if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+    const data = await res.json();
+
+    if (!Array.isArray(data) || data.length === 0) {
+      return setStatus("No contributors found yet.");
+    }
+    grid.innerHTML = ""; // clear status
+    data.forEach(renderCard);
+  } catch (e) {
+    setStatus("Failed to load contributors. Try again later.", true);
+    // console.debug(e);
+  }
+})();


### PR DESCRIPTION
## Description
Adds a **Contributors** page (GitHub API) + a **“View Contributors”** button.  
Keeps existing style, responsive cards, fixed avatar size, name ellipsis + tooltips.

## Test
- Open homepage → click **View Contributors**.
- Check grid, hover tooltips, and mobile layout.

## Related
Close #308 

## Results
Add a button on the homepage that links to the Contributors page.
<img width="1253" height="364" alt="image" src="https://github.com/user-attachments/assets/74797660-2672-4939-ae68-37343b76c1c5" />

The Contributors page
<img width="1129" height="799" alt="image" src="https://github.com/user-attachments/assets/35e5e7df-65a1-42f3-825c-55e897f3db1b" />

## Hacktoberfest
Please add `hacktoberfest` / `hacktoberfest-accepted` labels. Thanks!

