### PR TITLE
Quick Fix: Use relative paths for static assets in contributors.html

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta name="description" content="Contributors of The Button That Does Nothing"/>
-  <link rel="icon" type="image/svg+xml" href="/image/favicon.ico"/>
-  <link rel="stylesheet" href="/css/style.css"/>
-  <link rel="stylesheet" href="/css/contributors.css"/>
+  <link rel="icon" type="image/svg+xml" href="image/favicon.ico"/>
+  <link rel="stylesheet" href="css/style.css"/>
+  <link rel="stylesheet" href="css/contributors.css"/>
   <title>Contributors — The Button That Does Nothing</title>
 </head>
 <body class="bg">
@@ -14,7 +14,7 @@
     <header class="page-header">
       <h1>The Legends Behind The Button</h1> 
       <p class="subtitle">Thanks to everyone who clicked… and actually built things.</p>
-      <a class="btn btn-secondary" href="/index.html">← Back to the Button</a>
+      <a class="btn btn-secondary" href="index.html">← Back to the Button</a>
     </header>
 
     <section id="contributors" class="contributors-grid" aria-live="polite"></section>
@@ -37,6 +37,6 @@
   <script>
     window.__REPO__ = { owner: "thecodersroom", name: "the-button-that-does-nothing" };
   </script>
-  <script type="module" src="/js/contributors.js"></script>
+  <script type="module" src="js/contributors.js"></script>
 </body>
 </html>


### PR DESCRIPTION
@AbdulKhadhar 

This PR updates asset paths in `contributors.html` from absolute (`/css/style.css`) to relative (`css/style.css`) to ensure compatibility with GitHub Pages project site deployments. Now all CSS, JS, icon, and internal links load correctly on the live site. Fixes the resource loading issue and prevents blank/unstyled contributor page for users. Review and merge to resolve the display bug.

Issue : #313 